### PR TITLE
Fix repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Because I get asked about this quite a bit, I’ve decided to create a version o
 
 While you can download the auto-updater source as well as the example usage projects, you can also simply add the feature to your product using this p2 repository.
 
-https://github.com/modular-mind/updatemanager/tree/master/repository
+https://github.com/modular-mind/updatemanager/raw/master/repository/
 
 When you run your application, the `UpdateManager` service will be deployed using Declarative Services and can be accessed as other OSGi services can.
 


### PR DESCRIPTION
First up, thanks for sharing this project! Very helpful indeed.

Simply linking to the `tree` doesn't work, as the repo isn't being served as an update site.
A hacky solution (used in this PR) is to use the `raw`-qualified URL.

A more comfortable solution is to use GitHub Pages to serve the p2 repo. There are some working solutions (automated via CI) out there, e.g., [via GitHub Actions](https://github.com/korpling/pepper/blob/59c734e96c9efe9da9984406ab62ce431de633f5/.github/workflows/deploy.yml) (quite a complex example, but it works).

As a sidenote, I think it'd be great if you added a LICENSE file to the root. You do mention that you share the code under EPL (and I believe all the necessary files are there to fulfill the license), but it helps users a lot if they would find this information more visibly.

Thanks!